### PR TITLE
:unlock: Run as current user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ node_modules/
 
 # Brunch output folder.
 public/
+
+# Docker environment home folder
+.home/

--- a/interactive.sh
+++ b/interactive.sh
@@ -1,1 +1,3 @@
-docker run -it --rm -p 3333:3333 -v ${PWD}:/src -w /src node:9.11.1 bash
+#!/bin/bash
+mkdir -p .home
+docker run -it --rm -p 3333:3333 -u $(id -u):$(id -g) -e "HOME=/src/.home" -v ${PWD}:/src -w /src node:9.11.1 bash


### PR DESCRIPTION
Problem:
- Running `interactive.sh` creates root-owned folders and files on my
filesystem

Solution:
- Start the docker container with the UID and GID of the current user so
that the files will be correctly owned

Notes:
- This may require first removing the root-owned folders prior to being
able to run as a non-privileged user