### PR TITLE
:clubs: Shuffle answers

### DIFF
--- a/app/lib/questions.js
+++ b/app/lib/questions.js
@@ -24,7 +24,13 @@ const all_sections = () => {
   return extra_sections.map((s) => s.section )
 }
 
+const shuffle_answers = (q) => {
+  q.answers = _.shuffle(q.answers)
+  return q
+}
+
+
 module.exports = {
-  for_sections: (sections) => _.shuffle(questions_for_ids(ids_for_section(acl(sections)))),
+  for_sections: (sections) => _.shuffle(questions_for_ids(ids_for_section(acl(sections))).map(shuffle_answers)),
   all_sections: all_sections
 }

--- a/app/spec/questions.spec.js
+++ b/app/spec/questions.spec.js
@@ -20,4 +20,9 @@ describe("questions", () => {
     assert.equal(q1.length, q2.length)
     assert.notDeepEqual(q1, q2)
   })
+  it("should shuffle answers on subsequent calls", () => {
+    const a1 = questions.for_sections("4.1")[0].answers
+    const a2 = questions.for_sections("4.1")[0].answers
+    assert.notDeepEqual(a1, a2)
+  })
 })


### PR DESCRIPTION
Problem:
- Answers for each question are always in the same order.

Solution:
- Shuffle the answers for every question every time a new set of questions is retrieved.

Note:
- The included test for this change is not always guaranteed to succeed. It checks for the answers being in a different order bewteen two calls, but it is possible that the same order can occur. This should be revisitied if it starts to affect running the tests in practice.