### PR TITLE
:8ball: Reveal the correct answer

### DIFF
--- a/app/assets/index.html
+++ b/app/assets/index.html
@@ -23,13 +23,13 @@
   </div>
   <div class="col-sm-10" id="right">
     <div id="questions">
-      <div data-bind="with: selectedQuestion">
+      <div data-bind="with: selectedQuestion, click: reveal_answer">
         <div data-bind="text: question"></div>
-          <ul data-bind="foreach: answers">
-            <li>
-              <span data-bind="text: text, style: { fontWeight: correct ? 'bold' : 'normal' }"></span>
-            </li>
-          </ul>
+        <ul data-bind="foreach: answers">
+          <li>
+            <span data-bind="text: text, style: { fontWeight: ($parents[1].show_answer() && correct) ? 'bold' : 'normal' }"></span>
+          </li>
+        </ul>
         </div>
         <div data-bind="visible: questions().length > 0">
         <button data-bind="click: previous, enable: hasPrevious">previous</button>

--- a/app/initialize.js
+++ b/app/initialize.js
@@ -6,23 +6,29 @@ document.addEventListener('DOMContentLoaded', () => {
     sections: ko.observableArray(),
     selectedSection: ko.observableArray(),
     questions: ko.observableArray(),
-    selectedIndex: ko.observable()
+    selectedIndex: ko.observable(),
+    show_answer: ko.observable(false),
   };
 
+  view_model.reveal_answer = () => { view_model.show_answer(true)}
+
   ko.computed(() => {
-    console.log("questions")
-    console.log(questions.for_sections(view_model.selectedSection()))
     view_model.questions(questions.for_sections(view_model.selectedSection()))
     view_model.selectedIndex(0)
+    view_model.show_answer(false)
   })
 
+  view_model.show_answer.subscribe(console.log)
   view_model.selectedQuestion = ko.computed(() => {
     return view_model.questions()[view_model.selectedIndex()]    
   })
+
   view_model.previous = () => {
+    view_model.show_answer(false)
     view_model.selectedIndex(view_model.selectedIndex()-1)
   }
   view_model.next = () => {
+    view_model.show_answer(false)
     view_model.selectedIndex(view_model.selectedIndex()+1)
   }
   view_model.hasPrevious = ko.computed(() => {


### PR DESCRIPTION
Problem:
- The correct answer is bolded as soon as the question is displayed.
- Always showing the correct answer provides no opportunity for the user
  to perform a forced recall of the correct answer.

Solution:
- Hide the aswer upon display of a new question.
- Reveal the answer when the question or answers are clicked on.