### PR TITLE
:white_check_mark: Display build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/cmotl/ham-tests.svg?branch=master)](https://travis-ci.org/cmotl/ham-tests)
+
 # Ham Tests
 
 ## Purpose


### PR DESCRIPTION
Problem:
- Build status is not obvious

Solution:
- Add a build status badge for the CI pipeline state