### PR TITLE
:skull: Update dependency vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3022,9 +3022,9 @@
       }
     },
     "jquery": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.12.4.tgz",
-      "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
       "dev": true
     },
     "js-tokens": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "uglify-js-brunch": "^2",
     "mocha": "^5.1.1",
     "json-brunch": "^1.5.4",
-    "jquery": "^1.11.0",
+    "jquery": "^3.3.1",
     "popper.js": "^1.14.0",
     "bootstrap": "^4.1.0"
   }


### PR DESCRIPTION
Problem:
- Github informed us of a vulnerability with the version of jQuery that was set as a dependency.

Solution:
- Update to a version that is no longer vulnerable.